### PR TITLE
GH-46222: [Python] Allow to specify footer when opening IPC file for writing

### DIFF
--- a/cpp/src/arrow/csv/converter_test.cc
+++ b/cpp/src/arrow/csv/converter_test.cc
@@ -660,6 +660,68 @@ TEST(TimestampConversion, UserDefinedParsersWithZone) {
   AssertConversionError(type, {"01/02/1970,1970-01-03T00:00:00+0000\n"}, {0}, options);
 }
 
+TEST(DurationConversion, Basics) {
+  auto type = duration(TimeUnit::SECOND);
+  AssertConversion<DurationType, int64_t>(
+      type, {"1,120\n", "10800,345600\n", "-1,-120\n", "-10800,-345600\n"},
+      {{1, 10800, -1, -10800}, {120, 345600, -120, -345600}});
+
+  type = duration(TimeUnit::MILLI);
+  AssertConversion<DurationType, int64_t>(
+      type, {"1000,120000\n", "10800000,345600000\n", "500,0\n", "-1000,-120000\n"},
+      {{1000, 10800000, 500, -1000}, {120000, 345600000, 0, -120000}});
+
+  type = duration(TimeUnit::MICRO);
+  AssertConversion<DurationType, int64_t>(
+      type, {"1000000,500000\n", "120000000,10800000000\n", "-500000,-1000000\n"},
+      {{1000000, 120000000, -500000}, {500000, 10800000000, -1000000}});
+
+  type = duration(TimeUnit::NANO);
+  AssertConversion<DurationType, int64_t>(
+      type,
+      {"1000000000,500000000\n", "120000000000,10800000000000\n", "7000,9\n",
+       "-7000,-9\n"},
+      {{1000000000, 120000000000, 7000, -7000}, {500000000, 10800000000000, 9, -9}});
+}
+
+TEST(DurationConversion, Nulls) {
+  auto type = duration(TimeUnit::MILLI);
+  AssertConversion<DurationType, int64_t>(type, {"1000,N/A\n", ",10800000\n"},
+                                          {{1000, 0}, {0, 10800000}},
+                                          {{true, false}, {false, true}});
+}
+
+TEST(DurationConversion, CustomNulls) {
+  auto options = ConvertOptions::Defaults();
+  options.null_values = {"xxx", "zzz"};
+
+  auto type = duration(TimeUnit::SECOND);
+  AssertConversion<DurationType, int64_t>(type, {"1,xxx\n"}, {{1}, {0}},
+                                          {{true}, {false}}, options);
+
+  options.quoted_strings_can_be_null = false;
+  AssertConversionError(type, {"\"1\",\"xxx\"\n"}, {1}, options);
+
+  AssertConversion<DurationType, int64_t>(type, {"1,xxx\n", "zzz,120\n"},
+                                          {{1, 0}, {0, 120}},
+                                          {{true, false}, {false, true}}, options);
+}
+
+TEST(DurationConversion, Whitespace) {
+  auto type = duration(TimeUnit::MILLI);
+  AssertConversion<DurationType, int64_t>(type,
+                                          {" 1000 , 120000 \n", " 500 , 10800000 \n"},
+                                          {{1000, 500}, {120000, 10800000}});
+}
+
+TEST(DurationConversion, Invalid) {
+  auto type = duration(TimeUnit::SECOND);
+  AssertConversionError(type, {"xyz\n"}, {0});
+  AssertConversionError(type, {"123abc\n"}, {0});
+  AssertConversionError(type, {"1.5\n"}, {0});  // floats not allowed
+  AssertConversionError(type, {"s1\n"}, {0});   // bad format
+}
+
 Decimal128 Dec128(std::string_view value) {
   Decimal128 dec;
   int32_t scale = 0;

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -265,6 +265,7 @@ can be chosen from the following list:
 * Binary and Large Binary
 * String and Large String (with optional UTF8 input validation)
 * Fixed-Size Binary
+* Duration (numeric strings matching the schema unit, e.g., "60000" for duration[ms])
 * Dictionary with index type Int32 and value type one of the following:
   Binary, String, LargeBinary, LargeString,  Int32, UInt32, Int64, UInt64,
   Float32, Float64, Decimal128

--- a/docs/source/python/csv.rst
+++ b/docs/source/python/csv.rst
@@ -30,7 +30,7 @@ The features currently offered are the following:
 * fetching column names from the first row in the CSV file
 * column-wise type inference and conversion to one of ``null``, ``int64``,
   ``float64``, ``date32``, ``time32[s]``, ``timestamp[s]``, ``timestamp[ns]``,
-  ``string`` or ``binary`` data
+  ``duration`` (from numeric strings), ``string`` or ``binary`` data
 * opportunistic dictionary encoding of ``string`` and ``binary`` columns
   (disabled by default)
 * detecting various spellings of null values such as ``NaN`` or ``#N/A``
@@ -124,6 +124,11 @@ a :class:`ConvertOptions` instance and pass it to :func:`read_csv`::
            'tip': pa.decimal128(precision=10, scale=2),
        }
    ))
+
+.. note::
+   To assign a column as ``duration``, the CSV values must be numeric strings
+   that match the expected unit (e.g. ``60000`` for 60 seconds when
+   using ``duration[ms]``).
 
 Available convert options are:
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1976,13 +1976,15 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
 
         CIpcReadStats stats()
 
+        shared_ptr[const CKeyValueMetadata] metadata()
+
     CResult[shared_ptr[CRecordBatchWriter]] MakeStreamWriter(
         shared_ptr[COutputStream] sink, const shared_ptr[CSchema]& schema,
         CIpcWriteOptions& options)
 
     CResult[shared_ptr[CRecordBatchWriter]] MakeFileWriter(
         shared_ptr[COutputStream] sink, const shared_ptr[CSchema]& schema,
-        CIpcWriteOptions& options)
+        CIpcWriteOptions& options, shared_ptr[const CKeyValueMetadata] metadata)
 
     CResult[unique_ptr[CMessage]] ReadMessage(CInputStream* stream,
                                               CMemoryPool* pool)

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -1201,9 +1201,11 @@ cdef class _RecordBatchFileReader(_Weakrefable):
     @property
     def metadata(self):
         """
-        File-level custom KeyValueMetadata written via ``ipc.new_file(..., metadata=)``.
+        File-level custom metadata as dict, where both keys and values are byte-like.
+        This kind of metadata can be written via ``ipc.new_file(..., metadata=...)``.
         """
-        return pyarrow_wrap_metadata(self.reader.get().metadata())
+        wrapped = pyarrow_wrap_metadata(self.reader.get().metadata())
+        return wrapped.to_dict() if wrapped is not None else None
 
 
 def get_tensor_size(Tensor tensor):

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -1020,15 +1020,21 @@ cdef class _RecordBatchStreamReader(RecordBatchReader):
 cdef class _RecordBatchFileWriter(_RecordBatchStreamWriter):
 
     def _open(self, sink, Schema schema not None,
-              IpcWriteOptions options=IpcWriteOptions()):
+              IpcWriteOptions options=IpcWriteOptions(),
+              metadata=None):
         cdef:
             shared_ptr[COutputStream] c_sink
+            shared_ptr[const CKeyValueMetadata] c_meta
 
         self.options = options.c_options
         get_writer(sink, &c_sink)
+
+        metadata = ensure_metadata(metadata, allow_none=True)
+        c_meta = pyarrow_unwrap_metadata(metadata)
+
         with nogil:
             self.writer = GetResultValue(
-                MakeFileWriter(c_sink, schema.sp_schema, self.options))
+                MakeFileWriter(c_sink, schema.sp_schema, self.options, c_meta))
 
 _RecordBatchWithMetadata = namedtuple(
     'RecordBatchWithMetadata',
@@ -1191,6 +1197,13 @@ cdef class _RecordBatchFileReader(_Weakrefable):
         if not self.reader:
             raise ValueError("Operation on closed reader")
         return _wrap_read_stats(self.reader.get().stats())
+
+    @property
+    def metadata(self):
+        """
+        File-level custom KeyValueMetadata written via ``ipc.new_file(..., metadata=)``.
+        """
+        return pyarrow_wrap_metadata(self.reader.get().metadata())
 
 
 def get_tensor_size(Tensor tensor):

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -69,6 +69,17 @@ options : pyarrow.ipc.IpcWriteOptions
     ARROW_PRE_1_0_METADATA_VERSION=1."""
 
 
+_ipc_file_writer_class_doc = (
+    _ipc_writer_class_doc
+    + "\n"
+    + """\
+metadata : dict | pyarrow.KeyValueMetadata, optional
+    Key/value pairs (both must be bytes-like) that will be stored
+    in the file footer and are retrievable via
+    pyarrow.ipc.open_file(...).metadata."""
+)
+
+
 class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
     __doc__ = """Writer for the Arrow streaming binary format
 
@@ -109,11 +120,12 @@ class RecordBatchFileWriter(lib._RecordBatchFileWriter):
 
     __doc__ = """Writer to create the Arrow binary file format
 
-{}""".format(_ipc_writer_class_doc)
+{}
+""".format(_ipc_file_writer_class_doc)
 
-    def __init__(self, sink, schema, *, options=None):
+    def __init__(self, sink, schema, *, options=None, metadata=None):
         options = _get_legacy_format_default(options)
-        self._open(sink, schema, options=options)
+        self._open(sink, schema, options=options, metadata=metadata)
 
 
 def _get_legacy_format_default(options):
@@ -180,9 +192,8 @@ def open_stream(source, *, options=None, memory_pool=None):
                                    memory_pool=memory_pool)
 
 
-def new_file(sink, schema, *, options=None):
-    return RecordBatchFileWriter(sink, schema,
-                                 options=options)
+def new_file(sink, schema, *, options=None, metadata=None):
+    return RecordBatchFileWriter(sink, schema, options=options, metadata=metadata)
 
 
 new_file.__doc__ = """\
@@ -194,7 +205,7 @@ Returns
 -------
 writer : RecordBatchFileWriter
     A writer for the given sink
-""".format(_ipc_writer_class_doc)
+""".format(_ipc_file_writer_class_doc)
 
 
 def open_file(source, footer_offset=None, *, options=None, memory_pool=None):

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1304,3 +1304,17 @@ def test_record_batch_reader_cast_nulls():
     casted_reader = reader.cast(schema_dst)
     with pytest.raises(pa.lib.ArrowInvalid, match="Can't cast array"):
         casted_reader.read_all()
+
+
+def test_record_batch_file_writer_with_metadata():
+    # https://github.com/apache/arrow/issues/46222
+    tbl = pa.table({"a": [1, 2, 3]})
+    meta = {b"creator": b"test", b"version": b"0.1.0"}
+    sink = pa.BufferOutputStream()
+
+    with pa.ipc.new_file(sink, tbl.schema, metadata=meta) as w:
+        w.write_table(tbl)
+
+    buffer = sink.getvalue()
+    with pa.ipc.open_file(buffer) as r:
+        assert dict(r.metadata) == meta

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1319,6 +1319,7 @@ def test_record_batch_file_writer_with_metadata():
     with pa.ipc.open_file(buffer) as r:
         assert r.metadata == meta
 
+
 def test_record_batch_file_writer_with_empty_metadata():
     # https://github.com/apache/arrow/issues/46222
     tbl = pa.table({"a": [1, 2, 3]})

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1317,4 +1317,16 @@ def test_record_batch_file_writer_with_metadata():
 
     buffer = sink.getvalue()
     with pa.ipc.open_file(buffer) as r:
-        assert dict(r.metadata) == meta
+        assert r.metadata == meta
+
+def test_record_batch_file_writer_with_empty_metadata():
+    # https://github.com/apache/arrow/issues/46222
+    tbl = pa.table({"a": [1, 2, 3]})
+    sink = pa.BufferOutputStream()
+
+    with pa.ipc.new_file(sink, tbl.schema) as w:
+        w.write_table(tbl)
+
+    buffer = sink.getvalue()
+    with pa.ipc.open_file(buffer) as r:
+        assert r.metadata is None


### PR DESCRIPTION
### Rationale for this change

The Arrow APIs for other languages offer to set the footer metadata of an IPC file, but pyarrow was lacking this.

### What changes are included in this PR?

A new keyword argument `metadata` in `RecordBatchFileWriter.__init__` as well as in `ipc.new_file`. The value is `None` by default to not break backwards compatibility.

Also added a `metadata` property to the `RecordBatchFileReader` to be able to extract the metadata easily.

### Are these changes tested?

Yes, by a unit test.

### Are there any user-facing changes?

Yes, see above.
